### PR TITLE
Attempts to fix #695

### DIFF
--- a/facebook-core/src/main/java/com/facebook/internal/InstallReferrerUtil.java
+++ b/facebook-core/src/main/java/com/facebook/internal/InstallReferrerUtil.java
@@ -25,7 +25,7 @@ public class InstallReferrerUtil {
 
     private static void tryConnectReferrerInfo(final Callback callback) {
         final InstallReferrerClient referrerClient = InstallReferrerClient.newBuilder(FacebookSdk.getApplicationContext()).build();
-        referrerClient.startConnection(new InstallReferrerStateListener() {
+        InstallReferrerStateListener installReferrerStateListener = new InstallReferrerStateListener() {
             @Override
             public void onInstallReferrerSetupFinished(int responseCode) {
                 switch (responseCode) {
@@ -33,7 +33,7 @@ public class InstallReferrerUtil {
                         ReferrerDetails response;
                         try {
                             response = referrerClient.getInstallReferrer();
-                        } catch (Exception e) {
+                        } catch (RemoteException e) {
                             return;
                         }
 
@@ -55,7 +55,13 @@ public class InstallReferrerUtil {
             @Override
             public void onInstallReferrerServiceDisconnected() {
             }
-        });
+        };
+
+        try {
+            referrerClient.startConnection(installReferrerStateListener);
+        } catch (Exception e) {
+            return;
+        }
     }
 
     private static void updateReferrer() {


### PR DESCRIPTION
Summary:
https://github.com/facebook/facebook-android-sdk/issues/695

InstallReferrerClientImpl tries to bind to a service inside startConnection, guess some OEMs don't allow that so catching all.

Reviewed By: joesus

Differential Revision: D20037257

fbshipit-source-id: 9d292bb4897372f635760d50aa90138154212a84

Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Describe what you accomplished in this pull request (for example, what happens before the change, and after the change)

## Test Plan

Test Plan: **Add your test plan here**
